### PR TITLE
Add checkbox selection for Primka items

### DIFF
--- a/VUVSkladiste/src/assets/Primka.jsx
+++ b/VUVSkladiste/src/assets/Primka.jsx
@@ -1,29 +1,15 @@
 import React, { useState, useEffect } from 'react';
-import { Form, Button, Container, Table, Card, Row, Col } from 'react-bootstrap';
+import { Form, Button, Container, Table, Card } from 'react-bootstrap';
 import axios from 'axios';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
-import { AddArtiklModal, DatumArtikliModal } from './modals';
 import { useNavigate } from 'react-router-dom';
 
 function Primka() {
     const [artikli, setArtikli] = useState([]);
-    const [jmjOptions, setJmjOptions] = useState([]);
-    const [kategorijeOptions, setKategorijeOptions] = useState([]);
-    const [showAddModal, setShowAddModal] = useState(false);
-    const [showDatumArtikliModal, setShowDatumArtikliModal] = useState(false);
-    const [selectedArtikl, setSelectedArtikl] = useState('');
-    const [kolicina, setKolicina] = useState('');
-    const [cijena, setCijena] = useState('');
     const [datumPrimke, setDatumPrimke] = useState(new Date());
-    const [dodaniArtikli, setDodaniArtikli] = useState([]);
-    const [ukupnaCijena, setUkupnaCijena] = useState(0);
-    const [ukupniZbrojCijena, setUkupniZbrojCijena] = useState(0);
     const [dokumentId, setDokumentId] = useState('');
 
     const [narudzbenice, setNarudzbenice] = useState([]);
     const [selectedNarudzbenicaId, setSelectedNarudzbenicaId] = useState('');
-    const [narudzbenaKolicina, setNarudzbenaKolicina] = useState('');
     const [dobavljacId, setDobavljacId] = useState('');
 
     const [userDetails, setUserDetails] = useState({ username: '', roles: [], UserId: "" });
@@ -106,7 +92,9 @@ function Primka() {
                     artiklNaziv: item.artiklNaziv,
                     artiklJmj: item.artiklJmj,
                     cijena: item.cijena,
-                    kolicina: item.kolicina
+                    kolicina: item.kolicina,
+                    selected: false,
+                    odabranaKolicina: item.kolicina
                 }));
 
                 const uniqueArtikli = Array.from(new Map(
@@ -114,9 +102,6 @@ function Primka() {
                 ).values());
 
                 setArtikli(uniqueArtikli);
-                setSelectedArtikl('');
-                setCijena('');
-                setNarudzbenaKolicina('');
             } catch (error) {
                 console.error("Greška pri dohvaćanju artikala:", error);
                 alert("Greška pri dohvaćanju artikala za narudžbenicu.");
@@ -127,52 +112,6 @@ function Primka() {
     }, [selectedNarudzbenicaId]);
 
     useEffect(() => {
-        if (selectedArtikl && selectedNarudzbenicaId) {
-            const artikl = artikli.find(
-                a => a.artiklId === parseInt(selectedArtikl)
-            );
-            if (artikl) {
-                setCijena(artikl.cijena);
-                setNarudzbenaKolicina(artikl.kolicina);
-            }
-        } else {
-            setCijena('');
-            setNarudzbenaKolicina('');
-        }
-    }, [selectedArtikl, selectedNarudzbenicaId, artikli]);
-
-    useEffect(() => {
-        const fetchKategorije = async () => {
-            try {
-                const response = await axios.get("https://localhost:5001/api/home/kategorije", {
-                    headers: {
-                        'Authorization': `Bearer ${sessionStorage.getItem('token')}`
-                    }
-                });
-                setKategorijeOptions(response.data);
-            } catch (error) {
-                console.error(error);
-                alert("Greška prilikom učitavanja podataka");
-            }
-        };
-
-        fetchKategorije();
-    }, []);
-
-    useEffect(() => {
-        if (kolicina && cijena) {
-            setUkupnaCijena(kolicina * cijena);
-        } else {
-            setUkupnaCijena(0);
-        }
-    }, [kolicina, cijena]);
-
-    useEffect(() => {
-        const zbrojCijena = dodaniArtikli.reduce((acc, artikl) => acc + artikl.ukupnaCijena, 0);
-        setUkupniZbrojCijena(zbrojCijena);
-    }, [dodaniArtikli]);
-
-    useEffect(() => {
         if (selectedNarudzbenicaId) {
             const narudzbenica = narudzbenice.find(n => n.dokumentId === parseInt(selectedNarudzbenicaId));
             if (narudzbenica) {
@@ -181,51 +120,19 @@ function Primka() {
         }
     }, [selectedNarudzbenicaId, narudzbenice]);
 
-    const handleAddArtikl = () => {
-        if (selectedArtikl && kolicina && cijena) {
-            const artikl = artikli.find(a => a.artiklId === parseInt(selectedArtikl));
-            const noviArtikl = {
-                redniBroj: dodaniArtikli.length + 1,
-                artiklId: artikl.artiklId,
-                artiklNaziv: artikl.artiklNaziv,
-                kolicina: kolicina,
-                cijena: cijena,
-                ukupnaCijena: kolicina * cijena
-            };
+    const odabraniArtikli = artikli
+        .filter(a => a.selected)
+        .map((a, index) => ({
+            redniBroj: index + 1,
+            artiklId: a.artiklId,
+            artiklNaziv: a.artiklNaziv,
+            kolicina: a.odabranaKolicina,
+            cijena: a.cijena,
+            ukupnaCijena: a.odabranaKolicina * a.cijena
+        }));
 
-            setDodaniArtikli([...dodaniArtikli, noviArtikl]);
-            resetForm();
-        }
-    };
+    const ukupniZbrojCijena = odabraniArtikli.reduce((acc, art) => acc + art.ukupnaCijena, 0);
 
-    const handleRemoveArtikl = (redniBroj) => {
-        const noviArtikli = dodaniArtikli.filter(artikl => artikl.redniBroj !== redniBroj)
-            .map((artikl, index) => ({
-                ...artikl,
-                redniBroj: index + 1
-            }));
-        setDodaniArtikli(noviArtikli);
-    };
-
-    const resetForm = () => {
-        setSelectedArtikl('');
-        setKolicina('');
-        setCijena('');
-        setNarudzbenaKolicina('');
-        setUkupnaCijena(0);
-    };
-
-    const resetFormAfterAdd = async () => {
-        setSelectedArtikl('');
-        setKolicina('');
-        setDodaniArtikli([]);
-        setCijena('');
-        setNarudzbenaKolicina('');
-        setUkupnaCijena(0);
-        const lastId = await getLastDokId();
-        setDokumentId(lastId + 1);
-        setDatumPrimke(new Date());
-    };
 
     return (
         <Container className="mt-5">
@@ -252,70 +159,51 @@ function Primka() {
                             </Form.Control>
                         </Form.Group>
 
-                        <Form.Group controlId="artiklSelect">
-                            <Form.Label>Odaberi Artikl</Form.Label>
-                            <Form.Control
-                                as="select"
-                                value={selectedArtikl}
-                                onChange={(e) => setSelectedArtikl(e.target.value)}
-                            >
-                                <option value="">Odaberi...</option>
-                                {artikli.map((artikl) => (
-                                    <option key={artikl.artiklId} value={artikl.artiklId}>
-                                        {artikl.artiklNaziv} ({artikl.artiklJmj})
-                                    </option>
-                                ))}
-                            </Form.Control>
-                        </Form.Group>
-
-                        {narudzbenaKolicina && (
-                            <div className="mb-2">
-                                <strong>Naručena količina:</strong> {narudzbenaKolicina}
-                            </div>
+                        {selectedNarudzbenicaId && (
+                            <Table striped bordered hover className="mt-3" variant="secondary">
+                                <thead>
+                                    <tr>
+                                        <th>Odaberi</th>
+                                        <th>ID</th>
+                                        <th>Naziv Artikla</th>
+                                        <th>Cijena</th>
+                                        <th>Količina</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {artikli.map((art) => (
+                                        <tr key={art.artiklId}>
+                                            <td>
+                                                <Form.Check
+                                                    type="checkbox"
+                                                    checked={art.selected || false}
+                                                    onChange={() => {
+                                                        setArtikli(prev => prev.map(a => a.artiklId === art.artiklId ? { ...a, selected: !a.selected } : a));
+                                                    }}
+                                                />
+                                            </td>
+                                            <td>{art.artiklId}</td>
+                                            <td>{art.artiklNaziv}</td>
+                                            <td>{art.cijena}</td>
+                                            <td>
+                                                {art.selected ? (
+                                                    <Form.Control
+                                                        type="number"
+                                                        value={art.odabranaKolicina}
+                                                        onChange={(e) => {
+                                                            const val = e.target.value;
+                                                            setArtikli(prev => prev.map(a => a.artiklId === art.artiklId ? { ...a, odabranaKolicina: val } : a));
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    art.kolicina
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
                         )}
-
-                        <Row className="mt-3">
-                            <Col>
-                                <Form.Group controlId="kolicinaInput">
-                                    <Form.Label>Unesi Količinu</Form.Label>
-                                    <Form.Control
-                                        type="number"
-                                        placeholder="Unesi količinu"
-                                        value={kolicina}
-                                        onChange={(e) => setKolicina(e.target.value)}
-                                    />
-                                </Form.Group>
-                            </Col>
-                            <Col>
-                                <Form.Group controlId="cijenaInput">
-                                    <Form.Label>Cijena (iz narudžbenice)</Form.Label>
-                                    <Form.Control
-                                        type="number"
-                                        value={cijena}
-                                        readOnly
-                                    />
-                                </Form.Group>
-                            </Col>
-                            <Col>
-                                <Form.Group controlId="ukupnaCijenaDisplay">
-                                    <Form.Label>Ukupna Cijena</Form.Label>
-                                    <Form.Control
-                                        type="text"
-                                        value={ukupnaCijena.toFixed(2)}
-                                        readOnly
-                                    />
-                                </Form.Group>
-                            </Col>
-                        </Row>
-
-                        <div className="d-flex justify-content-between mt-3">
-                            <Button variant="primary" onClick={handleAddArtikl}>
-                                Dodaj Artikl
-                            </Button>
-                            <Button variant="secondary" onClick={resetForm}>
-                                Odustani
-                            </Button>
-                        </div>
                     </Form>
                 </Card.Body>
             </Card>
@@ -326,7 +214,7 @@ function Primka() {
                     onClick={() => {
                         navigate('/primkanova', {
                             state: {
-                                dodaniArtikli,
+                                dodaniArtikli: odabraniArtikli,
                                 datumPrimke,
                                 dokumentId,
                                 UserId: userDetails.UserId,
@@ -336,74 +224,15 @@ function Primka() {
                             }
                         });
                     }}
-                    disabled={dodaniArtikli.length === 0 || !dobavljacId}
+                    disabled={odabraniArtikli.length === 0 || !dobavljacId}
                 >
                     Pregledaj artikle i napravi primku
                 </Button>
             </div>
 
-            <h3 className="mt-4">Dodani Artikli</h3>
-            <Table striped bordered hover variant="secondary">
-                <thead>
-                    <tr>
-                        <th>#</th>
-                        <th>ID</th>
-                        <th>Naziv Artikla</th>
-                        <th>Količina</th>
-                        <th>Cijena</th>
-                        <th>Ukupna Cijena</th>
-                        <th>/</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {dodaniArtikli.map((artikl, index) => (
-                        <tr key={index}>
-                            <td>{artikl.redniBroj}</td>
-                            <td>{artikl.artiklId}</td>
-                            <td>{artikl.artiklNaziv}</td>
-                            <td>{artikl.kolicina}</td>
-                            <td>{artikl.cijena}</td>
-                            <td>{artikl.ukupnaCijena.toFixed(2)} €</td>
-                            <td>
-                                <Button variant="danger" onClick={() => handleRemoveArtikl(artikl.redniBroj)}>
-                                    Obriši
-                                </Button>
-                            </td>
-                        </tr>
-                    ))}
-                    <tr>
-                        <td colSpan="5" className="text-right"><strong>Ukupno:</strong></td>
-                        <td><strong>{ukupniZbrojCijena.toFixed(2)} €</strong></td>
-                        <td></td>
-                    </tr>
-                </tbody>
-            </Table>
-
             <div className="total-price-footer">
                 <h4>Ukupan Zbroj Cijena: {ukupniZbrojCijena.toFixed(2)} €</h4>
             </div>
-
-            <AddArtiklModal
-                show={showAddModal}
-                handleClose={() => setShowAddModal(false)}
-                handleSave={(newArtikl) => {
-                    setDodaniArtikli([...dodaniArtikli, newArtikl]);
-                    setShowAddModal(false);
-                }}
-                jmjOptions={jmjOptions}
-                kategorijeOptions={kategorijeOptions}
-            />
-
-            <DatumArtikliModal
-                show={showDatumArtikliModal}
-                handleClose={() => setShowDatumArtikliModal(false)}
-                dokumentId={dokumentId}
-                datumPrimke={datumPrimke}
-                setDatumPrimke={setDatumPrimke}
-                dodaniArtikli={dodaniArtikli}
-                resetForm={resetFormAfterAdd}
-                UserId={userDetails.UserId}
-            />
         </Container>
     );
 }


### PR DESCRIPTION
## Summary
- change Primka UI to show order items in a table with checkboxes
- compute selected items and total based on table input
- send selected items to the preview page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686442e682c88325a9f377aaa0bf51cb