### PR TITLE
Move ArtikliDokumenta endpoints to HomeController

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -29,6 +29,8 @@ namespace SKLADISTE.Repository.Common
         Task<bool> AddKategorijaAsync(Kategorija kat);
         Task<bool> AddDokumentAsync(Dokument dokument);
         Task<bool> AddArtiklDokumentaAsync(ArtikliDokumenata artDok);
+        Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync();
+        Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id);
 
         IEnumerable<Kategorija> GetAllKategorije();
         Task<bool> DeleteArtiklAsync(int artiklId);

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -271,6 +271,16 @@ namespace SKLADISTE.Repository
             await _appDbContext.SaveChangesAsync();
             return true;
         }
+
+        public async Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync()
+        {
+            return await _appDbContext.ArtikliDokumenata.ToListAsync();
+        }
+
+        public async Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id)
+        {
+            return await _appDbContext.ArtikliDokumenata.FirstOrDefaultAsync(a => a.Id == id);
+        }
         //vracanje svih kategorija
         public IEnumerable<Kategorija> GetAllKategorije()
         {

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -29,6 +29,8 @@ namespace SKLADISTE.Service.Common
 
         Task<bool> AddDokumentAsync(Dokument dokument);
         Task<bool> AddArtiklDokumenta(ArtikliDokumenata artDok);
+        Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync();
+        Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id);
 
         IEnumerable<Kategorija> GetAllKategorijeS();
 

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -99,6 +99,16 @@ namespace SKLADISTE.Service
             return await _repository.AddArtiklDokumentaAsync(artDok);
         }
 
+        public async Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync()
+        {
+            return await _repository.GetAllArtikliDokumenataAsync();
+        }
+
+        public async Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id)
+        {
+            return await _repository.GetArtikliDokumentaByIdAsync(id);
+        }
+
         public IEnumerable<Kategorija> GetAllKategorijeS()
         {
             IEnumerable<Kategorija> artiklDb = _repository.GetAllKategorije();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -342,6 +342,23 @@ namespace SKLADISTE.WebAPI.Controllers
             }
         }
 
+        [HttpGet("artikli_dokumenta")]
+        public async Task<IActionResult> GetAllArtikliDokumenata()
+        {
+            var data = await _service.GetAllArtikliDokumenataAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("artikli_dokumenta/{id}")]
+        public async Task<IActionResult> GetArtikliDokumentaById(int id)
+        {
+            var item = await _service.GetArtikliDokumentaByIdAsync(id);
+            if (item == null)
+                return NotFound();
+
+            return Ok(item);
+        }
+
 
         //vracanje svih kategorija
         [HttpGet("kategorije")]


### PR DESCRIPTION
## Summary
- remove dedicated `ArtikliDokumentaController`
- expose ArtikliDokumenta retrieval in `HomeController`

## Testing
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/SKLADISTE.WebAPI.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686452bf1ad88325aa12844fa0b703b7