### PR TITLE
Implement remaining quantity display for Primka

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -64,6 +64,8 @@ namespace SKLADISTE.Repository.Common
 
         Task<List<PrimNaruArtiklDto>> GetArtikliInfoByPrimkaId(int primkaId);
 
+        Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId);
+
         // IEnumerable<> GetAllArtiklsUlazDb();
         /*   IEnumerable<Artikl> GetAllArtiklsDb();
        IEnumerable<RobaStanje> GetAllArtiklsStanjeDb();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -664,6 +664,27 @@ namespace SKLADISTE.Repository
             return artikli;
         }
 
+        public async Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId)
+        {
+            var primkaArtikli = await _appDbContext.ArtikliDokumenata
+                .Where(ad => ad.DokumentId == primkaId)
+                .ToListAsync();
+
+            foreach (var pArt in primkaArtikli)
+            {
+                var narArt = await _appDbContext.ArtikliDokumenata
+                    .FirstOrDefaultAsync(ad => ad.DokumentId == narudzbenicaId && ad.ArtiklId == pArt.ArtiklId);
+
+                if (narArt != null)
+                {
+                    narArt.TrenutnaKolicina += pArt.TrenutnaKolicina;
+                }
+            }
+
+            await _appDbContext.SaveChangesAsync();
+            return true;
+        }
+
     }
 
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -64,5 +64,7 @@ namespace SKLADISTE.Service.Common
         Task<PrimkaInfoDto> GetPrimkaInfoByIdAsync(int primkaId);
         Task<List<PrimNaruArtiklDto>> GetArtikliInfoByPrimkaId(int primkaId);
 
+        Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId);
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -211,5 +211,10 @@ namespace SKLADISTE.Service
             return await _repository.GetArtikliInfoByPrimkaId(primkaId);
         }
 
+        public async Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId)
+        {
+            return await _repository.AzurirajNarudzbenicaKolicineAsync(narudzbenicaId, primkaId);
+        }
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -715,6 +715,16 @@ namespace SKLADISTE.WebAPI.Controllers
             return Ok(result);
         }
 
+        [HttpPost("azuriraj_narudzbenica_kolicine")]
+        public async Task<IActionResult> AzurirajNarudzbenicaKolicine([FromBody] PrimNaruVezeDto dto)
+        {
+            var result = await _service.AzurirajNarudzbenicaKolicineAsync(dto.NarudzbenicaId, dto.PrimkaId);
+            if (result)
+                return Ok("Kolicine azurirane.");
+
+            return StatusCode(500, "Greska kod azuriranja kolicina.");
+        }
+
 
     }
 

--- a/VUVSkladiste/src/assets/Primka.jsx
+++ b/VUVSkladiste/src/assets/Primka.jsx
@@ -93,15 +93,18 @@ function Primka() {
                     artiklJmj: item.artiklJmj,
                     cijena: item.cijena,
                     kolicina: item.kolicina,
+                    trenutnaKolicina: item.trenutnaKolicina,
                     selected: false,
-                    odabranaKolicina: item.kolicina
+                    odabranaKolicina: Math.max(item.kolicina - item.trenutnaKolicina, 0)
                 }));
 
                 const uniqueArtikli = Array.from(new Map(
                     filtrirani.map(art => [art.artiklId, art])
                 ).values());
 
-                setArtikli(uniqueArtikli);
+                const dostupni = uniqueArtikli.filter(a => a.odabranaKolicina > 0);
+
+                setArtikli(dostupni);
             } catch (error) {
                 console.error("Greška pri dohvaćanju artikala:", error);
                 alert("Greška pri dohvaćanju artikala za narudžbenicu.");
@@ -121,7 +124,7 @@ function Primka() {
     }, [selectedNarudzbenicaId, narudzbenice]);
 
     const odabraniArtikli = artikli
-        .filter(a => a.selected)
+        .filter(a => a.selected && a.odabranaKolicina > 0)
         .map((a, index) => ({
             redniBroj: index + 1,
             artiklId: a.artiklId,
@@ -171,7 +174,7 @@ function Primka() {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {artikli.map((art) => (
+                                    {artikli.filter(a => a.odabranaKolicina > 0).map((art) => (
                                         <tr key={art.artiklId}>
                                             <td>
                                                 <Form.Check
@@ -196,7 +199,7 @@ function Primka() {
                                                         }}
                                                     />
                                                 ) : (
-                                                    art.kolicina
+                                                    Math.max(art.kolicina - art.trenutnaKolicina, 0)
                                                 )}
                                             </td>
                                         </tr>

--- a/VUVSkladiste/src/assets/PrimkaNova.jsx
+++ b/VUVSkladiste/src/assets/PrimkaNova.jsx
@@ -19,7 +19,8 @@ function PrimkaNova() {
         return `${month.padStart(2, '0')}.${day.padStart(2, '0')}.${year}`;
     };
     const oznaka = generirajOznakuDokumenta();
-    const ukupniZbrojCijena = dodaniArtikli?.reduce((acc, item) => acc + item.ukupnaCijena, 0) || 0;
+    const filtriraniArtikli = dodaniArtikli?.filter(a => a.kolicina > 0) || [];
+    const ukupniZbrojCijena = filtriraniArtikli.reduce((acc, item) => acc + item.ukupnaCijena, 0);
 
     const handleCreatePrimka = async () => {
         const formattedDate = formatDateForAPI(datumPrimke);
@@ -46,7 +47,7 @@ function PrimkaNova() {
                 return;
             }
 
-            for (const artikl of dodaniArtikli) {
+            for (const artikl of filtriraniArtikli) {
                 const artiklBody = {
                     id: 0,
                     DokumentId: dokumentId,
@@ -76,6 +77,10 @@ function PrimkaNova() {
             };
             console.log(vezaBody)
             await axios.post('https://localhost:5001/api/home/kreiraj_primnaru', vezaBody, {
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            await axios.post('https://localhost:5001/api/home/azuriraj_narudzbenica_kolicine', vezaBody, {
                 headers: { 'Content-Type': 'application/json' }
             });
 
@@ -111,7 +116,7 @@ function PrimkaNova() {
                     </tr>
                 </thead>
                 <tbody>
-                    {dodaniArtikli.map((artikl, index) => (
+                    {filtriraniArtikli.map((artikl, index) => (
                         <tr key={index}>
                             <td>{artikl.redniBroj}</td>
                             <td>{artikl.artiklId}</td>


### PR DESCRIPTION
## Summary
- compute remaining quantity per Narudzbenica item when creating Primka
- default Primka quantity input shows only the quantity left to receive
- keep difference visible in the item list
- hide items with no remaining quantity when creating or reviewing Primka

## Testing
- `npm run lint` *(fails: could not read package.json)*
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee967660832591186cd5f2f826f5