### PR TITLE
Prevent duplicate artikl dropdown options

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -29,6 +29,7 @@ namespace SKLADISTE.Repository.Common
         Task<bool> AddKategorijaAsync(Kategorija kat);
         Task<bool> AddDokumentAsync(Dokument dokument);
         Task<bool> AddArtiklDokumentaAsync(ArtikliDokumenata artDok);
+        Task<bool> UpdateArtiklDokumentaAsync(int dokumentId, int artiklId, float kolicina, float cijena);
         Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync();
         Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id);
 

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -29,6 +29,7 @@ namespace SKLADISTE.Service.Common
 
         Task<bool> AddDokumentAsync(Dokument dokument);
         Task<bool> AddArtiklDokumenta(ArtikliDokumenata artDok);
+        Task<bool> UpdateArtiklDokumentaAsync(int dokumentId, int artiklId, float kolicina, float cijena);
         Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync();
         Task<ArtikliDokumenata?> GetArtikliDokumentaByIdAsync(int id);
 

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -99,6 +99,11 @@ namespace SKLADISTE.Service
             return await _repository.AddArtiklDokumentaAsync(artDok);
         }
 
+        public async Task<bool> UpdateArtiklDokumentaAsync(int dokumentId, int artiklId, float kolicina, float cijena)
+        {
+            return await _repository.UpdateArtiklDokumentaAsync(dokumentId, artiklId, kolicina, cijena);
+        }
+
         public async Task<IEnumerable<ArtikliDokumenata>> GetAllArtikliDokumenataAsync()
         {
             return await _repository.GetAllArtikliDokumenataAsync();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -327,19 +327,34 @@ namespace SKLADISTE.WebAPI.Controllers
             try
             {
                 bool result = await _service.AddArtiklDokumenta(artDok);
+
                 if (result)
                 {
                     return Ok("Artikl added successfully.");
                 }
                 else
                 {
-                    return StatusCode(500, "Internal server error while adding artikl.");
+                    return Conflict("Artikl je već dodan u narudžbenicu.");
                 }
             }
             catch (Exception ex)
             {
                 return StatusCode(500, "Internal server error: " + ex.Message);
             }
+        }
+
+        [HttpPut("update_artDok")]
+        public async Task<IActionResult> UpdateArtiklDok([FromBody] ArtiklDokumentUpdateRequest request)
+        {
+            if (request == null)
+                return BadRequest("Prazan zahtjev.");
+
+            var result = await _service.UpdateArtiklDokumentaAsync(request.DokumentId, request.ArtiklId, request.Kolicina, request.Cijena);
+
+            if (result)
+                return Ok("ArtiklDokumenta updated.");
+
+            return NotFound("ArtiklDokumenta nije pronađen.");
         }
 
         [HttpGet("artikli_dokumenta")]
@@ -741,6 +756,14 @@ namespace SKLADISTE.WebAPI.Controllers
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string UserName { get; set; }
+    }
+
+    public class ArtiklDokumentUpdateRequest
+    {
+        public int DokumentId { get; set; }
+        public int ArtiklId { get; set; }
+        public float Kolicina { get; set; }
+        public float Cijena { get; set; }
     }
 
 }

--- a/VUVSkladiste/src/assets/NarudzbenicaDetalji.jsx
+++ b/VUVSkladiste/src/assets/NarudzbenicaDetalji.jsx
@@ -1,13 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { Container, Card, Table, Button, Spinner, Modal } from 'react-bootstrap';
+import { Container, Card, Table, Button, Spinner, Modal, Form, Row, Col } from 'react-bootstrap';
 
 function NarudzbenicaDetalji() {
     const [showModal, setShowModal] = useState(false);
     const [deleting, setDeleting] = useState(false);
     const [changingStatus, setChangingStatus] = useState(false);
-    const [statusZatvoren, setStatusZatvoren] = useState(false);
+    const [closingStatus, setClosingStatus] = useState(false);
+    const [aktivniStatusId, setAktivniStatusId] = useState(null);
+    const [showAddForm, setShowAddForm] = useState(false);
+    const [allArtikli, setAllArtikli] = useState([]);
+    const [selectedArtikl, setSelectedArtikl] = useState('');
+    const [kolicinaArtikla, setKolicinaArtikla] = useState('');
+    const [cijenaArtikla, setCijenaArtikla] = useState('');
+    const [ukupnoArtikla, setUkupnoArtikla] = useState(0);
+    const [addingArtikl, setAddingArtikl] = useState(false);
+    const [editingArtiklId, setEditingArtiklId] = useState(null);
+    const [editKolicina, setEditKolicina] = useState('');
+    const [editCijena, setEditCijena] = useState('');
+    const [savingEdit, setSavingEdit] = useState(false);
     const { id } = useParams();
     const navigate = useNavigate();
 
@@ -18,6 +30,28 @@ function NarudzbenicaDetalji() {
     const [detalji, setDetalji] = useState(null);
     const [nazivPlacanja, setNazivPlacanja] = useState(null);
     const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchAllArtikli = async () => {
+            try {
+                const res = await axios.get('https://localhost:5001/api/home/artikli_db', {
+                    headers: { Authorization: `Bearer ${sessionStorage.getItem('token')}` }
+                });
+                setAllArtikli(res.data);
+            } catch (err) {
+                console.error(err);
+            }
+        };
+        fetchAllArtikli();
+    }, []);
+
+    useEffect(() => {
+        if (kolicinaArtikla && cijenaArtikla) {
+            setUkupnoArtikla(parseFloat(kolicinaArtikla) * parseFloat(cijenaArtikla));
+        } else {
+            setUkupnoArtikla(0);
+        }
+    }, [kolicinaArtikla, cijenaArtikla]);
 
     const handleDelete = async () => {
         setDeleting(true);
@@ -63,8 +97,8 @@ function NarudzbenicaDetalji() {
 
             if (res.status === 200) {
                 alert("Status uspješno promijenjen.");
-                setStatusDokumenta("Zatvorena");
-                setStatusZatvoren(true);
+                setStatusDokumenta("Isporuka");
+                setAktivniStatusId(3);
             } else {
                 alert("Greška pri promjeni statusa.");
             }
@@ -74,6 +108,144 @@ function NarudzbenicaDetalji() {
         } finally {
             setChangingStatus(false);
         }
+    };
+
+    const handleZatvoriNarudzbenicu = async () => {
+        const token = sessionStorage.getItem('token');
+        const zaposlenikId = sessionStorage.getItem('UserId');
+
+        if (!zaposlenikId) {
+            alert("Korisnik nije prijavljen.");
+            return;
+        }
+
+        setClosingStatus(true);
+        try {
+            const body = {
+                dokumentId: parseInt(id),
+                statusId: 2, //2=zatvoren
+                datum: new Date().toISOString(),
+                zaposlenikId
+            };
+
+            const res = await axios.put(
+                `https://localhost:5001/api/home/uredi_status_dokumenta`,
+                body,
+                { headers: { Authorization: `Bearer ${token}` } }
+            );
+
+            if (res.status === 200) {
+                alert("Status uspješno promijenjen.");
+                setStatusDokumenta("Zatvorena");
+                setAktivniStatusId(2);
+            } else {
+                alert("Greška pri promjeni statusa.");
+            }
+        } catch (err) {
+            console.error(err);
+            alert("Došlo je do greške.");
+        } finally {
+            setClosingStatus(false);
+        }
+    };
+
+    const handleDodajArtikl = async () => {
+        if (!selectedArtikl || !kolicinaArtikla || !cijenaArtikla) {
+            alert('Popunite sva polja.');
+            return;
+        }
+        if (artikli.some(a => a.artiklId === parseInt(selectedArtikl))) {
+            alert('Artikl je već dodan.');
+            return;
+        }
+        setAddingArtikl(true);
+        const token = sessionStorage.getItem('token');
+        const zaposlenikId = sessionStorage.getItem('UserId');
+        try {
+            const body = {
+                id: 0,
+                DokumentId: parseInt(id),
+                RbArtikla: artikli.length + 1,
+                Kolicina: parseFloat(kolicinaArtikla),
+                Cijena: parseFloat(cijenaArtikla),
+                UkupnaCijena: parseFloat(kolicinaArtikla) * parseFloat(cijenaArtikla),
+                ArtiklId: parseInt(selectedArtikl),
+                TrenutnaKolicina: 0,
+                ZaposlenikId: zaposlenikId
+            };
+
+            const res = await axios.post('https://localhost:5001/api/home/add_artDok', body, {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (res.status === 200) {
+                const artResponse = await axios.get(`https://localhost:5001/api/home/artikli_by_dokument/${id}`, {
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                setArtikli(artResponse.data);
+                setSelectedArtikl('');
+                setKolicinaArtikla('');
+                setCijenaArtikla('');
+                setShowAddForm(false);
+            } else {
+                alert('Greška pri dodavanju artikla.');
+            }
+        } catch (err) {
+            if (err.response && err.response.status === 409) {
+                alert('Artikl je već dodan.');
+            } else {
+                console.error(err);
+                alert('Došlo je do greške.');
+            }
+        } finally {
+            setAddingArtikl(false);
+        }
+    };
+
+    const handleEditClick = (a) => {
+        setEditingArtiklId(a.artiklId);
+        setEditKolicina(a.kolicina);
+        setEditCijena(a.cijena);
+    };
+
+    const handleSaveEdit = async () => {
+        if (!editKolicina || !editCijena) {
+            alert('Popunite sva polja.');
+            return;
+        }
+        setSavingEdit(true);
+        const token = sessionStorage.getItem('token');
+        try {
+            const body = {
+                DokumentId: parseInt(id),
+                ArtiklId: editingArtiklId,
+                Kolicina: parseFloat(editKolicina),
+                Cijena: parseFloat(editCijena)
+            };
+            await axios.put('https://localhost:5001/api/home/update_artDok', body, {
+                headers: { Authorization: `Bearer ${token}` }
+            });
+
+            const artResponse = await axios.get(`https://localhost:5001/api/home/artikli_by_dokument/${id}`, {
+                headers: { Authorization: `Bearer ${token}` }
+            });
+            setArtikli(artResponse.data);
+            setEditingArtiklId(null);
+        } catch (err) {
+            console.error(err);
+            alert('Greška pri ažuriranju.');
+        } finally {
+            setSavingEdit(false);
+        }
+    };
+
+    const handleCancelEdit = () => {
+        setEditingArtiklId(null);
+        setEditKolicina('');
+        setEditCijena('');
     };
 
     useEffect(() => {
@@ -110,11 +282,14 @@ function NarudzbenicaDetalji() {
                     headers: { 'Authorization': `Bearer ${token}` }
                 });
                 if (statusResponse.data && statusResponse.data.length > 0) {
-                    const aktivni = statusResponse.data.find(s => s.aktivan === true);
+                    const aktivni = statusResponse.data.find(
+                        s => s.aktivan === true || s.aktivan === 1 || s.Aktivan === true || s.Aktivan === 1
+                    );
                     const latest = statusResponse.data[statusResponse.data.length - 1];
-                    const naziv = aktivni?.statusNaziv || latest.statusNaziv;
+                    const naziv = aktivni?.statusNaziv || aktivni?.StatusNaziv || latest.statusNaziv || latest.StatusNaziv;
+                    const idStatusa = aktivni?.statusId || aktivni?.StatusId || latest.statusId || latest.StatusId;
                     setStatusDokumenta(naziv);
-                    if (naziv?.toLowerCase().includes('zatvor')) setStatusZatvoren(true);
+                    setAktivniStatusId(parseInt(idStatusa, 10));
                 }
 
                 const detaljiResponse = await axios.get(`https://localhost:5001/api/home/narudzbenica_detalji/${id}`, {
@@ -178,6 +353,7 @@ function NarudzbenicaDetalji() {
                                     <th>Količina</th>
                                     <th>Cijena</th>
                                     <th>Ukupna cijena</th>
+                                    {aktivniStatusId === 1 && <th></th>}
                                 </tr>
                             </thead>
                             <tbody>
@@ -187,9 +363,35 @@ function NarudzbenicaDetalji() {
                                         <td>{a.artiklId}</td>
                                         <td>{a.artiklNaziv}</td>
                                         <td>{a.artiklJmj}</td>
-                                        <td>{a.kolicina}</td>
-                                        <td>{a.cijena}</td>
-                                        <td>{a.ukupnaCijena}</td>
+                                        <td>
+                                            {editingArtiklId === a.artiklId ? (
+                                                <Form.Control type="number" value={editKolicina} onChange={e => setEditKolicina(e.target.value)} />
+                                            ) : (
+                                                a.kolicina
+                                            )}
+                                        </td>
+                                        <td>
+                                            {editingArtiklId === a.artiklId ? (
+                                                <Form.Control type="number" value={editCijena} onChange={e => setEditCijena(e.target.value)} />
+                                            ) : (
+                                                a.cijena
+                                            )}
+                                        </td>
+                                        <td>{editingArtiklId === a.artiklId ? (parseFloat(editKolicina || 0) * parseFloat(editCijena || 0)).toFixed(2) : a.ukupnaCijena}</td>
+                                        {aktivniStatusId === 1 && (
+                                            <td>
+                                                {editingArtiklId === a.artiklId ? (
+                                                    <>
+                                                        <Button variant="success" size="sm" className="me-1" onClick={handleSaveEdit} disabled={savingEdit}>
+                                                            {savingEdit ? 'Spremam...' : 'Spremi'}
+                                                        </Button>
+                                                        <Button variant="secondary" size="sm" onClick={handleCancelEdit}>Odustani</Button>
+                                                    </>
+                                                ) : (
+                                                    <Button variant="outline-primary" size="sm" onClick={() => handleEditClick(a)}>Uredi</Button>
+                                                )}
+                                            </td>
+                                        )}
                                     </tr>
                                 ))}
                             </tbody>
@@ -198,11 +400,65 @@ function NarudzbenicaDetalji() {
                         <p>Ova narudžbenica nema artikala.</p>
                     )}
 
+                    {aktivniStatusId === 1 && !showAddForm && (
+                        <Button variant="primary" className="mt-2" onClick={() => setShowAddForm(true)}>
+                            Dodaj Artikl
+                        </Button>
+                    )}
+
+                    {aktivniStatusId === 1 && showAddForm && (
+                        <div className="mt-3">
+                            <Row>
+                                <Col>
+                                    <Form.Group>
+                                        <Form.Label>Artikl</Form.Label>
+                                        <Form.Control as="select" value={selectedArtikl} onChange={(e) => setSelectedArtikl(e.target.value)}>
+                                            <option value="">-- Odaberi --</option>
+                                            {allArtikli
+                                                .filter(a => !artikli.some(exists => exists.artiklId === a.artiklId))
+                                                .map(a => (
+                                                    <option key={a.artiklId} value={a.artiklId}>
+                                                        {a.artiklNaziv} ({a.artiklJmj})
+                                                    </option>
+                                                ))}
+                                        </Form.Control>
+                                    </Form.Group>
+                                </Col>
+                                <Col>
+                                    <Form.Group>
+                                        <Form.Label>Količina</Form.Label>
+                                        <Form.Control type="number" value={kolicinaArtikla} onChange={(e) => setKolicinaArtikla(e.target.value)} />
+                                    </Form.Group>
+                                </Col>
+                                <Col>
+                                    <Form.Group>
+                                        <Form.Label>Cijena</Form.Label>
+                                        <Form.Control type="number" value={cijenaArtikla} onChange={(e) => setCijenaArtikla(e.target.value)} />
+                                    </Form.Group>
+                                </Col>
+                                <Col>
+                                    <Form.Group>
+                                        <Form.Label>Ukupno</Form.Label>
+                                        <Form.Control type="text" value={ukupnoArtikla.toFixed(2)} readOnly />
+                                    </Form.Group>
+                                </Col>
+                            </Row>
+                            <div className="mt-2">
+                                <Button variant="success" onClick={handleDodajArtikl} disabled={addingArtikl} className="me-2">
+                                    {addingArtikl ? 'Spremam...' : 'Spremi'}
+                                </Button>
+                                <Button variant="secondary" onClick={() => { setShowAddForm(false); setSelectedArtikl(''); setKolicinaArtikla(''); setCijenaArtikla(''); }}>
+                                    Odustani
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+
                     <Button variant="danger" className="ms-2" onClick={() => setShowModal(true)}>
                         Obriši narudžbenicu
                     </Button>
 
-                    {!statusZatvoren && (
+                    {aktivniStatusId !== 3 && aktivniStatusId !== 2 && (
                         <Button
                             variant="warning"
                             onClick={handlePromijeniStatus}
@@ -210,6 +466,17 @@ function NarudzbenicaDetalji() {
                             className="me-2"
                         >
                             {changingStatus ? 'Šaljem...' : 'Isporuka'}
+                        </Button>
+                    )}
+
+                    {aktivniStatusId !== 2 && (
+                        <Button
+                            variant="success"
+                            onClick={handleZatvoriNarudzbenicu}
+                            disabled={closingStatus}
+                            className="me-2"
+                        >
+                            {closingStatus ? 'Zatvaram...' : 'Zatvori narudžbenicu'}
                         </Button>
                     )}
 

--- a/VUVSkladiste/src/assets/Narudzbenice.jsx
+++ b/VUVSkladiste/src/assets/Narudzbenice.jsx
@@ -68,9 +68,11 @@ function Narudzbenice() {
                     'Authorization': `Bearer ${sessionStorage.getItem('token')}`
                 }
             });
-            const aktivni = response.data.find(s => s.aktivan === true);
+            const aktivni = response.data.find(
+                s => s.aktivan === true || s.aktivan === 1 || s.Aktivan === true || s.Aktivan === 1
+            );
             const latest = response.data[response.data.length - 1];
-            const naziv = aktivni?.statusNaziv || latest?.statusNaziv || "Nepoznat";
+            const naziv = aktivni?.statusNaziv || aktivni?.StatusNaziv || latest?.statusNaziv || latest?.StatusNaziv || "Nepoznat";
             setStatusi(prev => ({ ...prev, [dokumentId]: naziv }));
         } catch (err) {
             console.error(`Greška pri dohvaćanju statusa za dokument ${dokumentId}`, err);


### PR DESCRIPTION
## Summary
- hide articles already in document when selecting a new item
- fix status detection by treating `aktivan` as numeric from API

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6867b33efa508325abac98a335a414dd