### PR TITLE
Filter narudžbenice by active status

### DIFF
--- a/VUVSkladiste/src/assets/Primka.jsx
+++ b/VUVSkladiste/src/assets/Primka.jsx
@@ -39,7 +39,10 @@ function Primka() {
             ]);
 
             const zatvoreniStatusi = statusResponse.data
-                .filter(ds => ds.statusId === 3) // provjera ako je status isporuka
+                .filter(ds =>
+                    ds.statusId === 3 &&
+                    (ds.aktivan === true || ds.aktivan === 1 || ds.Aktivan === true || ds.Aktivan === 1)
+                )
                 .map(ds => ds.dokumentId);
 
             const filtriraneNarudzbenice = narudzbeniceResponse.data.filter(n =>


### PR DESCRIPTION
## Summary
- filter narudžbenice in `Primka.jsx` to only display those with active "Isporuka" status

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68685566b20083258e9724e4959a5a0e