### PR TITLE
Fix EF comparison in cleanup method

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -726,8 +726,8 @@ namespace SKLADISTE.Repository
                       ds => ds.StatusId,
                       st => st.StatusId,
                       (ds, st) => new { ds.Dokument, st.StatusNaziv })
-                .Where(x => !string.Equals(x.StatusNaziv, "zatvorena", StringComparison.OrdinalIgnoreCase) &&
-                             !string.Equals(x.StatusNaziv, "zatvoren", StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.StatusNaziv.ToLower() != "zatvorena" &&
+                             x.StatusNaziv.ToLower() != "zatvoren")
                 .Select(x => x.Dokument)
                 .ToListAsync();
 


### PR DESCRIPTION
## Summary
- use EF-translatable comparison in ObrisiStareOtvoreneNarudzbeniceAsync

## Testing
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.sln' -c Release`
- `dotnet run --project 'SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/SKLADISTE.WebAPI.csproj'` *(fails: Application startup exception)*

------
https://chatgpt.com/codex/tasks/task_e_68692a534b808325b5af05d02c2bf953