### PR TITLE
Fix deletion to target open orders

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -726,8 +726,8 @@ namespace SKLADISTE.Repository
                       ds => ds.StatusId,
                       st => st.StatusId,
                       (ds, st) => new { ds.Dokument, st.StatusNaziv })
-                .Where(x => !string.Equals(x.StatusNaziv, "zatvorena", StringComparison.OrdinalIgnoreCase) &&
-                             !string.Equals(x.StatusNaziv, "zatvoren", StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.StatusNaziv.ToLower() == "otvorena" ||
+                             x.StatusNaziv.ToLower() == "otvoren")
                 .Select(x => x.Dokument)
                 .ToListAsync();
 


### PR DESCRIPTION
## Summary
- delete only narudzbenice with the `Otvoren` status

## Testing
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.sln' -c Release`
- `dotnet run --project 'SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/SKLADISTE.WebAPI.csproj'` *(fails: missing .NET 3.1 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68692a534b808325b5af05d02c2bf953