### PR TITLE
Update warning highlight condition for orders

### DIFF
--- a/VUVSkladiste/src/assets/Narudzbenice.jsx
+++ b/VUVSkladiste/src/assets/Narudzbenice.jsx
@@ -175,7 +175,8 @@ function Narudzbenice() {
                     {filteredNarudzbenice.map((art, index) => {
                         const rok = rokovi[art.dokumentId] ? new Date(rokovi[art.dokumentId]) : null;
                         let rowClass = '';
-                        if (rok) {
+                        const statusNaziv = statusi[art.dokumentId]?.toLowerCase();
+                        if (rok && statusNaziv === 'isporuka') {
                             const today = new Date();
                             today.setHours(0,0,0,0);
                             const rokDate = new Date(rok);


### PR DESCRIPTION
## Summary
- highlight deadline warnings only when an order's status is "Isporuka"

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686934d855bc8325899b9f5ddb456732