### PR TITLE
Add sidebar dropdowns

### DIFF
--- a/VUVSkladiste/eslint.config.cjs
+++ b/VUVSkladiste/eslint.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./.eslintrc.cjs');

--- a/VUVSkladiste/src/assets/login_register_navbar.jsx
+++ b/VUVSkladiste/src/assets/login_register_navbar.jsx
@@ -7,6 +7,9 @@ import logo from './img/logo.png';
 function Navigacija() {
   const [userDetails, setUserDetails] = useState({ username: '', roles: [], UserId: "" });
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [artikliOpen, setArtikliOpen] = useState(false);
+  const [dokumentiOpen, setDokumentiOpen] = useState(false);
+  const [narudzbenicaOpen, setNarudzbenicaOpen] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -52,18 +55,45 @@ function Navigacija() {
        
         <ul className="sidebar-links ">
           <li><Link to="/PocetnaStranica">Početna</Link></li>
-          <li><Link to="/Stanja">Artikli</Link></li>
-          <li><Link to="/Dokumenti">Dokumenti</Link></li>
-          <li><Link to="/Primka">Nova Primka</Link></li>
-          <li><Link to="/Izdatnica">Nova Izdatnica</Link></li>
+          <li>
+            <div className="d-flex justify-content-between" onClick={() => setArtikliOpen(!artikliOpen)}>
+              <Link to="/Stanja">Artikli</Link>
+              <span style={{ cursor: 'pointer' }}>{artikliOpen ? '▲' : '▼'}</span>
+            </div>
+            {artikliOpen && (
+              <ul className="submenu">
+                <li><Link to="/DodajNoviArtikl">Dodaj Artikl</Link></li>
+                <li><Link to="/dodajkategoriju">Dodaj Kategoriju</Link></li>
+              </ul>
+            )}
+          </li>
+          <li>
+            <div className="d-flex justify-content-between" onClick={() => setDokumentiOpen(!dokumentiOpen)}>
+              <Link to="/Dokumenti">Dokumenti</Link>
+              <span style={{ cursor: 'pointer' }}>{dokumentiOpen ? '▲' : '▼'}</span>
+            </div>
+            {dokumentiOpen && (
+              <ul className="submenu">
+                <li><Link to="/Primka">Nova Primka</Link></li>
+                <li><Link to="/Izdatnica">Nova Izdatnica</Link></li>
+              </ul>
+            )}
+          </li>
           <li><Link to="/SkladistePodaci">Podaci o Skladištu</Link></li>
-         
-          
-          <li><Link to="/Narudzbenice">Narudžbenice</Link></li>
-          <li><Link to="/NarudzbenicaNova">Nova Narudžbenica</Link></li>
+          <li>
+            <div className="d-flex justify-content-between" onClick={() => setNarudzbenicaOpen(!narudzbenicaOpen)}>
+              <Link to="/Narudzbenice">Narudžbenice</Link>
+              <span style={{ cursor: 'pointer' }}>{narudzbenicaOpen ? '▲' : '▼'}</span>
+            </div>
+            {narudzbenicaOpen && (
+              <ul className="submenu">
+                <li><Link to="/NarudzbenicaNova">Nova Narudžbenica</Link></li>
+              </ul>
+            )}
+          </li>
           <li><Link to="/Dobavljaci">Dobavljači</Link></li>
           <li><Link to="/Zaposlenici">Zaposlenici</Link></li>
-           <li><Link to="/Statistika">Statistika</Link></li>
+          <li><Link to="/Statistika">Statistika</Link></li>
 
         </ul>
       </div>

--- a/VUVSkladiste/src/index.css
+++ b/VUVSkladiste/src/index.css
@@ -249,6 +249,7 @@ body {
 
 .sidebar-links li {
   padding: 10px 20px;
+  font-size: 0.9rem;
 }
 
 .sidebar-links a {
@@ -258,6 +259,17 @@ body {
 
 .sidebar-links a:hover {
   text-decoration: underline;
+}
+
+/* Submenu styling */
+.submenu {
+  list-style: none;
+  padding-left: 15px;
+  margin: 0;
+}
+
+.submenu li {
+  padding: 5px 20px;
 }
 
 /* Top navbar */


### PR DESCRIPTION
## Summary
- tweak sidebar styling and add submenu styles
- use smaller font for sidebar links
- add dropdown options for Dokumenti and Narudzbenice
- enable dropdown menu for Artikli with links to add new item and category

## Testing
- `npm run lint` *(fails: config not compatible with ESLint 9)*
- `npm run build` *(fails: rollup optional dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68742b6b0a348325b3a9ccd53749cba6