### PR TITLE
Improve light theme

### DIFF
--- a/VUVSkladiste/src/assets/Dokumenti.jsx
+++ b/VUVSkladiste/src/assets/Dokumenti.jsx
@@ -90,7 +90,7 @@ function Dokumenti() {
                 />
             </Form.Group>
 
-            <Table className="centered-table mt-3" striped bordered hover variant="dark">
+            <Table className="centered-table mt-3" striped bordered hover variant="light">
                 <thead>
                     <tr>
                         <th>Id dokumenta</th>

--- a/VUVSkladiste/src/assets/Izdatnica.jsx
+++ b/VUVSkladiste/src/assets/Izdatnica.jsx
@@ -201,7 +201,7 @@ function Izdatnice() {
             </Card>
 
             <h3 className="mt-4">Dodani Artikli</h3>
-            <Table striped bordered hover variant="secondary">
+            <Table striped bordered hover variant="light">
                 <thead>
                     <tr>
                         <th>#</th>

--- a/VUVSkladiste/src/assets/Narudzbenice.jsx
+++ b/VUVSkladiste/src/assets/Narudzbenice.jsx
@@ -159,7 +159,7 @@ function Narudzbenice() {
                 />
             </Form.Group>
 
-            <Table className="centered-table mt-3" striped bordered hover variant="dark">
+            <Table className="centered-table mt-3" striped bordered hover variant="light">
                 <thead>
                     <tr>
                         <th>Id dokumenta</th>

--- a/VUVSkladiste/src/assets/Primka.jsx
+++ b/VUVSkladiste/src/assets/Primka.jsx
@@ -166,7 +166,7 @@ function Primka() {
                         </Form.Group>
 
                         {selectedNarudzbenicaId && (
-                            <Table striped bordered hover className="mt-3" variant="secondary">
+                            <Table striped bordered hover className="mt-3" variant="light">
                                 <thead>
                                     <tr>
                                         <th>Odaberi</th>

--- a/VUVSkladiste/src/assets/Stanja.jsx
+++ b/VUVSkladiste/src/assets/Stanja.jsx
@@ -219,7 +219,7 @@ function Stanja() {
                 />
             </Form.Group>
 
-            <Table className="centered-table mt-3" striped bordered hover variant="dark">
+            <Table className="centered-table mt-3" striped bordered hover variant="light">
                 <thead>
                     <tr>
                         <th>Oznaka</th>

--- a/VUVSkladiste/src/assets/Statistika.jsx
+++ b/VUVSkladiste/src/assets/Statistika.jsx
@@ -350,7 +350,7 @@ export function Statistika() {
             </div>
 
             <div style={{ flex: 1 }}>
-                <Table className="centered-table" striped bordered hover variant="dark" style={{ width: '90%' }}>
+                <Table className="centered-table" striped bordered hover variant="light" style={{ width: '90%' }}>
                     <thead>
                         <tr>
                             <th>Naziv Artikla</th>

--- a/VUVSkladiste/src/assets/dobavljaci.jsx
+++ b/VUVSkladiste/src/assets/dobavljaci.jsx
@@ -74,7 +74,7 @@ function Dobavljaci() {
             </Form.Group>
 
 
-            <Table className="centered-table mt-3" striped bordered hover variant="dark">
+            <Table className="centered-table mt-3" striped bordered hover variant="light">
                 <thead>
                     <tr>
                         <th>Naziv</th>

--- a/VUVSkladiste/src/assets/dobavljaciDokumenti.jsx
+++ b/VUVSkladiste/src/assets/dobavljaciDokumenti.jsx
@@ -74,7 +74,7 @@ function DobavljaciDokumenti() {
             {dokumenti.length === 0 ? (
                 <p className="mt-3">Nema dokumenata za ovog dobavljača.</p>
             ) : (
-                <Table className="centered-table mt-3" striped bordered hover variant="dark">
+                <Table className="centered-table mt-3" striped bordered hover variant="light">
                     <thead>
                         <tr>
                             <th>Oznaka</th>

--- a/VUVSkladiste/src/assets/login_register_navbar.jsx
+++ b/VUVSkladiste/src/assets/login_register_navbar.jsx
@@ -102,7 +102,7 @@ function Navigacija() {
       
       <div className="topbar">
         <img src={logo} alt="logo" className="navbar-logo ms-3 mt-2" />
-        <span className="ms-auto text-white">
+        <span className="ms-auto">
           
           {isLoggedIn && `Trenutni račun: ${userDetails.username}`}
         </span>

--- a/VUVSkladiste/src/assets/zaposlenici.jsx
+++ b/VUVSkladiste/src/assets/zaposlenici.jsx
@@ -60,7 +60,7 @@ function Zaposlenici() {
             >
                 Dodaj zaposlenika
             </Button>
-            <Table className="centered-table mt-3" striped bordered hover variant="dark" style={{ width: '60%' }}>
+            <Table className="centered-table mt-3" striped bordered hover variant="light" style={{ width: '60%' }}>
                 <thead>
                     <tr>
                         <th>Korisničko ime</th>

--- a/VUVSkladiste/src/index.css
+++ b/VUVSkladiste/src/index.css
@@ -1,6 +1,7 @@
 /* ItemForm.css */
 body {
-  background-color: rgb(76, 86, 95);
+  background-color: #f8f9fa;
+  font-size: 0.85rem;
 }
 
 .centered-table {
@@ -15,36 +16,36 @@ body {
 }
 
 .centered-table th {
-  background-color: #343a40;
-  color: white;
+  background-color: #e9ecef;
+  color: black;
 }
 
 .centered-table tr:nth-child(even) {
-  background-color: #454d55;
+  background-color: #f5f5f5;
 }
 
 .centered-table tr:hover {
-  background-color: #5a6268;
+  background-color: #e2e6ea;
 }
 .navbar-logo {
   height: 50px;
 }
 .form {
-  background-color: #3b3f45;
+  background-color: #ffffff;
   padding: 20px;
   border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.9);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   margin-top: 50px; /* Adjust the margin-top to move the form up */
 }
 
 .form h2 {
-  color: white;
+  color: black;
   text-align: left;
   padding-top: 5px;
 }
 
 .form label {
-  color: white;
+  color: black;
 }
 
 .form input,
@@ -62,13 +63,13 @@ body {
   padding: 10px;
   border: none;
   border-radius: 4px;
-  background-color: #6c757d;
-  color: white;
+  background-color: #adb5bd;
+  color: black;
   cursor: pointer;
 }
 
 .form .btn:hover {
-  background-color: #5a6268;
+  background-color: #ced4da;
 }
 
 .form p {
@@ -81,8 +82,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #282c34;
-  color: white;
+  background-color: #ffffff;
+  color: black;
 }
 
 .App-header {
@@ -170,15 +171,15 @@ body {
   padding: 10px;
   border-radius: 4px;
   border: none;
-  background-color: #6c757d;
-  color: #fff;
+  background-color: #adb5bd;
+  color: #000;
 }
 
 .form-card {
-  background-color: rgb(113, 122, 129);
+  background-color: #ffffff;
   padding: 20px;
   border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
   margin-top: 20px;
 }
 
@@ -204,23 +205,23 @@ body {
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: #343a40a8;
-  color: #fff;
+  background-color: #f8f9fa;
+  color: #000;
   padding: 5px;
   text-align: center;
 }
 
 .primka-table th {
-  background-color: #343a40;
-  color: white;
+  background-color: #e9ecef;
+  color: black;
 }
 
 .primka-table tr:nth-child(even) {
-  background-color: #454d55;
+  background-color: #f5f5f5;
 }
 
 .primka-table tr:hover {
-  background-color: #5a6268;
+  background-color: #e2e6ea;
 }
 
 
@@ -235,8 +236,8 @@ body {
   left: 0;
   width: 220px;
   height: calc(100vh - 56px);
-  background-color: #343a40;
-  color: white;
+  background-color: #e9ecef;
+  color: black;
   padding-top: 1rem;
   z-index: 1000;
 }
@@ -253,7 +254,7 @@ body {
 }
 
 .sidebar-links a {
-  color: white;
+  color: black;
   text-decoration: none;
 }
 
@@ -279,11 +280,12 @@ body {
   left: 0;
   height: 56px;
   width: 100%;
-  background-color: #212529;
+  background-color: #f8f9fa;
   display: flex;
   align-items: center;
   padding: 0 1rem;
   z-index: 999;
+  color: black;
 }
 
 /* Glavni sadržaj */


### PR DESCRIPTION
## Summary
- switch tables to light variants
- lighten overall color scheme and make text smaller
- fix login navbar text color for light topbar

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6874334b5298832580f8fb9f6978b8c9