### PR TITLE
Dodana napomena na stranicama primke i izdatnice

### DIFF
--- a/VUVSkladiste/src/assets/IzdatnicaArtikliPage.jsx
+++ b/VUVSkladiste/src/assets/IzdatnicaArtikliPage.jsx
@@ -11,7 +11,7 @@ function IzdatnicaArtikliPage() {
     const location = useLocation();
     const navigate = useNavigate();
 
-    const {
+    const { 
         dodaniArtikli,
         datumIzdatnice,
         dokumentId,
@@ -20,6 +20,7 @@ function IzdatnicaArtikliPage() {
     } = location.state || {};
 
     const [selectedDate, setSelectedDate] = useState(datumIzdatnice || new Date());
+    const [napomena, setNapomena] = useState('');
     const oznaka = generirajOznakuDokumenta();
 
     if (!dodaniArtikli) {
@@ -43,7 +44,7 @@ function IzdatnicaArtikliPage() {
             DatumDokumenta: formattedDate,
             TipDokumentaId: 2,
             ZaposlenikId: UserId,
-            Napomena: "",
+            Napomena: napomena,
             DobavljacId: 1,
             OznakaDokumenta: oznaka,
             MjestoTroska: mjestoTroska
@@ -150,6 +151,17 @@ function IzdatnicaArtikliPage() {
                     onChange={(date) => setSelectedDate(date)}
                     dateFormat="dd.MM.yyyy"
                     className="form-control"
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+                <Form.Label>Napomena</Form.Label>
+                <Form.Control
+                    as="textarea"
+                    rows={3}
+                    value={napomena}
+                    onChange={(e) => setNapomena(e.target.value)}
+                    placeholder="Unesite napomenu"
                 />
             </Form.Group>
 

--- a/VUVSkladiste/src/assets/PrimkaNova.jsx
+++ b/VUVSkladiste/src/assets/PrimkaNova.jsx
@@ -20,6 +20,7 @@ function PrimkaNova() {
     };
     const oznaka = generirajOznakuDokumenta();
     const [dostavio, setDostavio] = useState('');
+    const [napomena, setNapomena] = useState('');
     const filtriraniArtikli = dodaniArtikli?.filter(a => a.kolicina > 0) || [];
     const ukupniZbrojCijena = filtriraniArtikli.reduce((acc, item) => acc + item.ukupnaCijena, 0);
 
@@ -31,7 +32,7 @@ function PrimkaNova() {
             DatumDokumenta: formattedDate,
             TipDokumentaId: 1,
             ZaposlenikId: UserId,
-            Napomena: "",
+            Napomena: napomena,
             DobavljacId: dobavljacId,
             OznakaDokumenta: oznaka,
             PrimateljId: 0,
@@ -113,6 +114,17 @@ function PrimkaNova() {
                     value={dostavio}
                     onChange={(e) => setDostavio(e.target.value)}
                     placeholder="Unesite ime dostavljača"
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+                <Form.Label>Napomena</Form.Label>
+                <Form.Control
+                    as="textarea"
+                    rows={3}
+                    value={napomena}
+                    onChange={(e) => setNapomena(e.target.value)}
+                    placeholder="Unesite napomenu"
                 />
             </Form.Group>
 


### PR DESCRIPTION
## Summary
- proširene forme za kreiranje primke i izdatnice kako bi korisnik mogao unijeti napomenu
- slanje vrijednosti napomene API-ju prilikom spremanja dokumenata

## Testing
- `npm run lint` *(fails: A config object is using the "root" key)*
- `npx vite build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_687668bbfdc48325a927abfa9d664893