### PR TITLE
Add edit option in Artikl info

### DIFF
--- a/VUVSkladiste/src/assets/modals.jsx
+++ b/VUVSkladiste/src/assets/modals.jsx
@@ -332,7 +332,7 @@ export function InfoArtiklModal({ show, handleClose, artiklData, artiklName, kol
 
 
 
-function EditModal({ show, handleClose, jmjOptions, artiklName, artJmj, artKat, artiklId }) {
+export function EditModal({ show, handleClose, jmjOptions, artiklName, artJmj, artKat, artiklId }) {
     // States for form fields
     const [newName, setNewName] = useState('');
     const [jmj, setJmj] = useState('');


### PR DESCRIPTION
## Summary
- export `EditModal` from modals so it can be reused
- add edit modal support inside `ArtiklInfo`
- fetch category and JMJ options for editing
- show **Uredi** button in ArtiklInfo

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1db4a688325a095c7be2b9da0e1