### PR TITLE
Add Statistika API and page updates

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -73,6 +73,9 @@ namespace SKLADISTE.Repository.Common
         Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId);
         Task<int> ObrisiStareOtvoreneNarudzbeniceAsync();
 
+        IEnumerable<MonthlyStatsDto> GetMonthlyStats();
+        IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId);
+
         // IEnumerable<> GetAllArtiklsUlazDb();
         /*   IEnumerable<Artikl> GetAllArtiklsDb();
        IEnumerable<RobaStanje> GetAllArtiklsStanjeDb();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -841,6 +841,63 @@ namespace SKLADISTE.Repository
             return otvorene.Count;
         }
 
+        public IEnumerable<MonthlyStatsDto> GetMonthlyStats()
+        {
+            var grouped = _appDbContext.ArtikliDokumenata
+                .Join(
+                    _appDbContext.Dokumenti,
+                    ad => ad.DokumentId,
+                    d => d.DokumentId,
+                    (ad, d) => new { ad.UkupnaCijena, d.TipDokumentaId, d.DatumDokumenta })
+                .GroupBy(x => new { x.DatumDokumenta.Year, x.DatumDokumenta.Month })
+                .Select(g => new
+                {
+                    g.Key.Year,
+                    g.Key.Month,
+                    Primke = g.Sum(x => x.TipDokumentaId == 1 ? x.UkupnaCijena : 0),
+                    Izdatnice = g.Sum(x => x.TipDokumentaId == 2 ? x.UkupnaCijena : 0)
+                })
+                .OrderBy(x => x.Year)
+                .ThenBy(x => x.Month)
+                .ToList();
+
+            return grouped.Select(g => new MonthlyStatsDto
+            {
+                Mjesec = $"{g.Year}-{g.Month:D2}",
+                Primke = (double)g.Primke,
+                Izdatnice = (double)g.Izdatnice
+            });
+        }
+
+        public IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId)
+        {
+            var grouped = _appDbContext.ArtikliDokumenata
+                .Join(
+                    _appDbContext.Dokumenti,
+                    ad => ad.DokumentId,
+                    d => d.DokumentId,
+                    (ad, d) => new { ad.ArtiklId, ad.UkupnaCijena, d.TipDokumentaId, d.DatumDokumenta })
+                .Where(x => x.ArtiklId == artiklId)
+                .GroupBy(x => new { x.DatumDokumenta.Year, x.DatumDokumenta.Month })
+                .Select(g => new
+                {
+                    g.Key.Year,
+                    g.Key.Month,
+                    Primke = g.Sum(x => x.TipDokumentaId == 1 ? x.UkupnaCijena : 0),
+                    Izdatnice = g.Sum(x => x.TipDokumentaId == 2 ? x.UkupnaCijena : 0)
+                })
+                .OrderBy(x => x.Year)
+                .ThenBy(x => x.Month)
+                .ToList();
+
+            return grouped.Select(g => new MonthlyStatsDto
+            {
+                Mjesec = $"{g.Year}-{g.Month:D2}",
+                Primke = (double)g.Primke,
+                Izdatnice = (double)g.Izdatnice
+            });
+        }
+
     }
 
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -73,5 +73,8 @@ namespace SKLADISTE.Service.Common
         Task<bool> AzurirajNarudzbenicaKolicineAsync(int narudzbenicaId, int primkaId);
         Task<int> ObrisiStareOtvoreneNarudzbeniceAsync();
 
+        IEnumerable<MonthlyStatsDto> GetMonthlyStats();
+        IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId);
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -243,5 +243,15 @@ namespace SKLADISTE.Service
             return await _repository.ObrisiStareOtvoreneNarudzbeniceAsync();
         }
 
+        public IEnumerable<MonthlyStatsDto> GetMonthlyStats()
+        {
+            return _repository.GetMonthlyStats();
+        }
+
+        public IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId)
+        {
+            return _repository.GetMonthlyStatsForArtikl(artiklId);
+        }
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -793,6 +793,20 @@ namespace SKLADISTE.WebAPI.Controllers
             return StatusCode(500, "Greska kod azuriranja kolicina.");
         }
 
+        [HttpGet("monthly_stats")]
+        public IActionResult GetMonthlyStats()
+        {
+            var data = _service.GetMonthlyStats();
+            return Ok(data);
+        }
+
+        [HttpGet("monthly_stats/{artiklId}")]
+        public IActionResult GetMonthlyStatsForArtikl(int artiklId)
+        {
+            var data = _service.GetMonthlyStatsForArtikl(artiklId);
+            return Ok(data);
+        }
+
 
     }
 

--- a/SKLADISTE - Copy - Copy/Skladiste.Model/MonthlyStatsDto.cs
+++ b/SKLADISTE - Copy - Copy/Skladiste.Model/MonthlyStatsDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Skladiste.Model
+{
+    public class MonthlyStatsDto
+    {
+        public string Mjesec { get; set; }
+        public double Primke { get; set; }
+        public double Izdatnice { get; set; }
+    }
+}

--- a/VUVSkladiste/.eslintrc.cjs
+++ b/VUVSkladiste/.eslintrc.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  root: true,
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',

--- a/VUVSkladiste/package.json
+++ b/VUVSkladiste/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false node ./node_modules/eslint/bin/eslint.js . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/VUVSkladiste/src/assets/Pocetna.jsx
+++ b/VUVSkladiste/src/assets/Pocetna.jsx
@@ -53,7 +53,7 @@ function Pocetna() {
     const handleButtonClickNovaIzdatnica = () => {
         navigate('/Izdatnica'); // Ensure this path matches exactly
     }; const handleButtonClickStatistika = () => {
-        navigate('/Statistika'); // Ensure this path matches exactly
+        navigate('/statistika'); // Ensure this path matches exactly
     };
     const handleButtonClickZaposlenici = () => {
         navigate('/Zaposlenici'); // Ensure this path matches exactly

--- a/VUVSkladiste/src/assets/Statistika.jsx
+++ b/VUVSkladiste/src/assets/Statistika.jsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect } from 'react';
+import { Table, Modal, Button, Container, Card } from 'react-bootstrap';
+import axios from 'axios';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+function ArtiklStatModal({ show, handleClose, artiklName, monthData }) {
+  const chartData = {
+    labels: monthData.map(m => m.month),
+    datasets: [
+      {
+        label: 'Zarada',
+        data: monthData.map(m => m.profit),
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+      },
+    ],
+  };
+
+  return (
+    <Modal show={show} onHide={handleClose} size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Statistika Artikla: {artiklName}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Bar data={chartData} />
+        <Table striped bordered hover className="mt-3">
+          <thead>
+            <tr>
+              <th>Mjesec</th>
+              <th>Ukupno Primke</th>
+              <th>Ukupno Izdatnice</th>
+              <th>Zarada</th>
+            </tr>
+          </thead>
+          <tbody>
+            {monthData.map((m, idx) => (
+              <tr key={idx}>
+                <td>{m.month}</td>
+                <td>{m.primke.toFixed(2)}</td>
+                <td>{m.izdatnice.toFixed(2)}</td>
+                <td>{m.profit.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Zatvori
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+function Statistika() {
+  const [artikli, setArtikli] = useState([]);
+  const [monthlyData, setMonthlyData] = useState([]);
+  const [warehouseValue, setWarehouseValue] = useState(0);
+  const [selectedArtikl, setSelectedArtikl] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    const token = sessionStorage.getItem('token');
+    const headers = { Authorization: `Bearer ${token}` };
+
+    async function fetchData() {
+      try {
+        const [statsRes, artikliRes] = await Promise.all([
+          axios.get('https://localhost:5001/api/home/monthly_stats', { headers }),
+          axios.get('https://localhost:5001/api/home/artikli_db', { headers }),
+        ]);
+
+        const data = statsRes.data.map((m) => ({
+          month: m.mjesec,
+          primke: m.primke,
+          izdatnice: m.izdatnice,
+          profit: m.izdatnice - m.primke,
+        }));
+        let totalPrimke = 0;
+        let totalIzdatnice = 0;
+        data.forEach((d) => {
+          totalPrimke += d.primke;
+          totalIzdatnice += d.izdatnice;
+        });
+        setWarehouseValue(totalPrimke - totalIzdatnice);
+        setMonthlyData(data);
+        setArtikli(artikliRes.data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchData();
+  }, []);
+
+  const handleArtiklInfo = async (artikl) => {
+    const token = sessionStorage.getItem('token');
+    const headers = { Authorization: `Bearer ${token}` };
+    try {
+      const res = await axios.get(
+        `https://localhost:5001/api/home/monthly_stats/${artikl.artiklId}`,
+        { headers }
+      );
+      const data = res.data.map((m) => ({
+        month: m.mjesec,
+        primke: m.primke,
+        izdatnice: m.izdatnice,
+        profit: m.izdatnice - m.primke,
+      }));
+      setSelectedArtikl({ name: artikl.artiklNaziv, data });
+      setShowModal(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const chartData = {
+    labels: monthlyData.map((m) => m.month),
+    datasets: [
+      {
+        label: 'Zarada',
+        data: monthlyData.map((m) => m.profit),
+        backgroundColor: 'rgba(75,192,192,0.6)',
+      },
+    ],
+  };
+
+  return (
+    <Container className="mt-4">
+      <Card className="p-3 mb-4">
+        <h4 className="mb-3">Zarada po mjesecu</h4>
+        <Bar data={chartData} />
+        <Table striped bordered hover variant="light" className="mt-3">
+          <thead>
+            <tr>
+              <th>Mjesec</th>
+              <th>Ukupno Primke</th>
+              <th>Ukupno Izdatnice</th>
+              <th>Zarada</th>
+            </tr>
+          </thead>
+          <tbody>
+            {monthlyData.map((m, idx) => (
+              <tr key={idx}>
+                <td>{m.month}</td>
+                <td>{m.primke.toFixed(2)}</td>
+                <td>{m.izdatnice.toFixed(2)}</td>
+                <td>{m.profit.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+        <h5 className="mt-3">Trenutna vrijednost skladišta: {warehouseValue.toFixed(2)}</h5>
+      </Card>
+
+      <Card className="p-3">
+        <h4 className="mb-3">Artikli</h4>
+        <Table striped bordered hover variant="light">
+          <thead>
+            <tr>
+              <th>Oznaka</th>
+              <th>Naziv</th>
+              <th>Info</th>
+            </tr>
+          </thead>
+          <tbody>
+            {artikli.map((a) => (
+              <tr key={a.artiklId}>
+                <td>{a.artiklOznaka}</td>
+                <td>{a.artiklNaziv}</td>
+                <td>
+                  <Button variant="info" size="sm" onClick={() => handleArtiklInfo(a)}>
+                    Info
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Card>
+
+      {selectedArtikl && (
+        <ArtiklStatModal
+          show={showModal}
+          handleClose={() => setShowModal(false)}
+          artiklName={selectedArtikl.name}
+          monthData={selectedArtikl.data}
+        />
+      )}
+    </Container>
+  );
+}
+
+export default Statistika;

--- a/VUVSkladiste/src/assets/login_register_navbar.jsx
+++ b/VUVSkladiste/src/assets/login_register_navbar.jsx
@@ -93,7 +93,7 @@ function Navigacija() {
           </li>
           <li><Link to="/Dobavljaci">Dobavljači</Link></li>
           <li><Link to="/Zaposlenici">Zaposlenici</Link></li>
-          <li><Link to="/Statistika">Statistika</Link></li>
+          <li><Link to="/statistika">Statistika</Link></li>
 
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- create DTO `MonthlyStatsDto`
- add repository/service methods for monthly statistics
- expose API endpoints `/monthly_stats` and `/monthly_stats/{artiklId}`
- use new endpoints in `Statistika.jsx`
- fix monthly stats LINQ query and adjust navbar links
- tweak ESLint setup so local version runs
- fix monthly stats query translation

## Testing
- `npm run lint` *(fails with 128 errors from eslint)*
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d0cbecc88325a92cc8470388f4ad