### PR TITLE
Add daily stats endpoints and UI updates

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -76,6 +76,9 @@ namespace SKLADISTE.Repository.Common
         IEnumerable<MonthlyStatsDto> GetMonthlyStats();
         IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId);
 
+        IEnumerable<DailyStatsDto> GetDailyStatsLast30Days();
+        IEnumerable<DailyStatsDto> GetDailyStatsForMonth(int year, int month);
+
         // IEnumerable<> GetAllArtiklsUlazDb();
         /*   IEnumerable<Artikl> GetAllArtiklsDb();
        IEnumerable<RobaStanje> GetAllArtiklsStanjeDb();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -76,5 +76,8 @@ namespace SKLADISTE.Service.Common
         IEnumerable<MonthlyStatsDto> GetMonthlyStats();
         IEnumerable<MonthlyStatsDto> GetMonthlyStatsForArtikl(int artiklId);
 
+        IEnumerable<DailyStatsDto> GetDailyStatsLast30Days();
+        IEnumerable<DailyStatsDto> GetDailyStatsForMonth(int year, int month);
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -253,5 +253,15 @@ namespace SKLADISTE.Service
             return _repository.GetMonthlyStatsForArtikl(artiklId);
         }
 
+        public IEnumerable<DailyStatsDto> GetDailyStatsLast30Days()
+        {
+            return _repository.GetDailyStatsLast30Days();
+        }
+
+        public IEnumerable<DailyStatsDto> GetDailyStatsForMonth(int year, int month)
+        {
+            return _repository.GetDailyStatsForMonth(year, month);
+        }
+
     }
 }

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -807,6 +807,20 @@ namespace SKLADISTE.WebAPI.Controllers
             return Ok(data);
         }
 
+        [HttpGet("daily_stats_last30")]
+        public IActionResult GetDailyStatsLast30Days()
+        {
+            var data = _service.GetDailyStatsLast30Days();
+            return Ok(data);
+        }
+
+        [HttpGet("daily_stats/{year}/{month}")]
+        public IActionResult GetDailyStatsForMonth(int year, int month)
+        {
+            var data = _service.GetDailyStatsForMonth(year, month);
+            return Ok(data);
+        }
+
 
     }
 

--- a/SKLADISTE - Copy - Copy/Skladiste.Model/DailyStatsDto.cs
+++ b/SKLADISTE - Copy - Copy/Skladiste.Model/DailyStatsDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Skladiste.Model
+{
+    public class DailyStatsDto
+    {
+        public string Dan { get; set; }
+        public double Primke { get; set; }
+        public double Izdatnice { get; set; }
+    }
+}

--- a/VUVSkladiste/src/assets/Statistika.jsx
+++ b/VUVSkladiste/src/assets/Statistika.jsx
@@ -70,6 +70,9 @@ function Statistika() {
   const [warehouseValue, setWarehouseValue] = useState(0);
   const [selectedArtikl, setSelectedArtikl] = useState(null);
   const [showModal, setShowModal] = useState(false);
+  const [last30Data, setLast30Data] = useState([]);
+  const [selectedMonth, setSelectedMonth] = useState('');
+  const [dailyMonthData, setDailyMonthData] = useState([]);
 
   useEffect(() => {
     const token = sessionStorage.getItem('token');
@@ -77,9 +80,10 @@ function Statistika() {
 
     async function fetchData() {
       try {
-        const [statsRes, artikliRes] = await Promise.all([
+        const [statsRes, artikliRes, last30Res] = await Promise.all([
           axios.get('https://localhost:5001/api/home/monthly_stats', { headers }),
           axios.get('https://localhost:5001/api/home/artikli_db', { headers }),
+          axios.get('https://localhost:5001/api/home/daily_stats_last30', { headers }),
         ]);
 
         const data = statsRes.data.map((m) => ({
@@ -96,6 +100,13 @@ function Statistika() {
         });
         setWarehouseValue(totalPrimke - totalIzdatnice);
         setMonthlyData(data);
+        const last30 = last30Res.data.map(d => ({
+          day: d.dan,
+          primke: d.primke,
+          izdatnice: d.izdatnice,
+          profit: d.izdatnice - d.primke,
+        }));
+        setLast30Data(last30);
 
         setArtikli(artikliRes.data);
       } catch (err) {
@@ -128,21 +139,63 @@ function Statistika() {
 
   };
 
-  const chartData = {
-    labels: monthlyData.map((m) => m.month),
-    datasets: [
-      {
-        label: 'Zarada',
-        data: monthlyData.map((m) => m.profit),
-        backgroundColor: 'rgba(75,192,192,0.6)',
-      },
-    ],
+  const handleMonthChange = async (e) => {
+    const value = e.target.value;
+    setSelectedMonth(value);
+    if (!value) {
+      setDailyMonthData([]);
+      return;
+    }
+    const token = sessionStorage.getItem('token');
+    const headers = { Authorization: `Bearer ${token}` };
+    const [year, month] = value.split('-');
+    try {
+      const res = await axios.get(
+        `https://localhost:5001/api/home/daily_stats/${year}/${month}`,
+        { headers }
+      );
+      const data = res.data.map((d) => ({
+        day: d.dan,
+        primke: d.primke,
+        izdatnice: d.izdatnice,
+        profit: d.izdatnice - d.primke,
+      }));
+      setDailyMonthData(data);
+    } catch (err) {
+      console.error(err);
+    }
   };
+
+  const chartData = dailyMonthData.length > 0
+    ? {
+        labels: dailyMonthData.map(d => d.day),
+        datasets: [
+          {
+            label: 'Zarada',
+            data: dailyMonthData.map(d => d.profit),
+            backgroundColor: 'rgba(75,192,192,0.6)',
+          },
+        ],
+      }
+    : {
+        labels: monthlyData.map((m) => m.month),
+        datasets: [
+          {
+            label: 'Zarada',
+            data: monthlyData.map((m) => m.profit),
+            backgroundColor: 'rgba(75,192,192,0.6)',
+          },
+        ],
+      };
 
   return (
     <Container className="mt-4">
       <Card className="p-3 mb-4">
         <h4 className="mb-3">Zarada po mjesecu</h4>
+        <div className="mb-3">
+          <label className="me-2">Odaberi mjesec:</label>
+          <input type="month" value={selectedMonth} onChange={handleMonthChange} />
+        </div>
         <Bar data={chartData} />
         <Table striped bordered hover variant="light" className="mt-3">
           <thead>
@@ -165,6 +218,30 @@ function Statistika() {
           </tbody>
         </Table>
         <h5 className="mt-3">Trenutna vrijednost skladišta: {warehouseValue.toFixed(2)}</h5>
+      </Card>
+
+      <Card className="p-3 mb-4">
+        <h4 className="mb-3">Zarada zadnjih 30 dana</h4>
+        <Table striped bordered hover variant="light">
+          <thead>
+            <tr>
+              <th>Datum</th>
+              <th>Ukupno Primke</th>
+              <th>Ukupno Izdatnice</th>
+              <th>Zarada</th>
+            </tr>
+          </thead>
+          <tbody>
+            {last30Data.map((d, idx) => (
+              <tr key={idx}>
+                <td>{d.day}</td>
+                <td>{d.primke.toFixed(2)}</td>
+                <td>{d.izdatnice.toFixed(2)}</td>
+                <td>{d.profit.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
       </Card>
 
       <Card className="p-3">


### PR DESCRIPTION
## Summary
- support retrieval of daily profit data
- expose new API endpoints for daily stats
- allow month selection in stats view
- show last 30 days of revenue in table

## Testing
- `npm run lint` *(fails: React project has many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878e707df9883258366e099535834c1