### PR TITLE
Implement PDF email settings

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository.Common/IRepository.cs
@@ -49,6 +49,8 @@ namespace SKLADISTE.Repository.Common
         Task<bool> UpdateDobavljacAsync(Dobavljac dobavljac);
         Task<bool> DeleteDobavljacAsync(int id);
 
+        Task<string?> GetDobavljacEmailForDokumentAsync(int dokumentId);
+
         Task<SkladistePodatci?> GetSkladisteAsync();
         Task<bool> AddSkladisteAsync(SkladistePodatci skladiste);
         Task<bool> UpdateSkladisteAsync(SkladistePodatci skladiste);

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -465,6 +465,16 @@ namespace SKLADISTE.Repository
                 return false;
             }
         }
+
+        public async Task<string?> GetDobavljacEmailForDokumentAsync(int dokumentId)
+        {
+            var dokument = await _appDbContext.Dokumenti.FindAsync(dokumentId);
+            if (dokument == null)
+                return null;
+
+            var dobavljac = await _appDbContext.Dobavljaci.FindAsync(dokument.DobavljacId);
+            return dobavljac?.Email;
+        }
         public async Task<IEnumerable<Dokument>> GetDokumentiByDobavljacIdAsync(int dobavljacId)
         {
             return await _appDbContext.Dokumenti

--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service.Common/IService.cs
@@ -50,6 +50,8 @@ namespace SKLADISTE.Service.Common
         Task<bool> AddDobavljacAsync(Dobavljac dobavljac);
         Task<bool> UpdateDobavljacAsync(Dobavljac dobavljac);
         Task<bool> DeleteDobavljacAsync(int id);
+        Task<string?> GetDobavljacEmailForDokumentAsync(int dokumentId);
+        Task<bool> SendNarudzbenicaEmailAsync(int dokumentId, byte[] pdfData);
         Task<IEnumerable<Dokument>> GetDokumentiByDobavljacIdAsync(int dobavljacId);
 
         Task<SkladistePodatci?> GetSkladisteAsync();

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -821,6 +821,29 @@ namespace SKLADISTE.WebAPI.Controllers
             return Ok(data);
         }
 
+        [HttpPost("send_pdf/{dokumentId}")]
+        public async Task<IActionResult> SendPdfEmail(int dokumentId, [FromBody] EmailPdfRequest request)
+        {
+            if (request == null || string.IsNullOrEmpty(request.PdfBase64))
+                return BadRequest("Neispravni podaci.");
+
+            byte[] pdfBytes;
+            try
+            {
+                pdfBytes = Convert.FromBase64String(request.PdfBase64);
+            }
+            catch
+            {
+                return BadRequest("Neispravan PDF format.");
+            }
+
+            var result = await _service.SendNarudzbenicaEmailAsync(dokumentId, pdfBytes);
+            if (!result)
+                return StatusCode(500, "Greška pri slanju emaila.");
+
+            return Ok("Email poslan.");
+        }
+
 
     }
 

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Startup.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Startup.cs
@@ -13,6 +13,7 @@ using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using System.Threading.Tasks;
 using System;
+using Skladiste.Model;
 
 namespace SKLADISTE.WebAPI
 {
@@ -44,6 +45,7 @@ namespace SKLADISTE.WebAPI
 
             services.AddScoped<IService, Service.Service>();
             services.AddScoped<IRepository, Repository.Repository>();
+            services.Configure<Skladiste.Model.EmailSettings>(Configuration.GetSection("EmailSettings"));
             services.AddHostedService<NarudzbenicaCleanupService>();
 
             // Add CORS policy

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/appsettings.json
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/appsettings.json
@@ -13,5 +13,12 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EmailSettings": {
+    "FromAddress": "your@email.com",
+    "SmtpHost": "smtp.example.com",
+    "SmtpPort": 587,
+    "Username": "user",
+    "Password": "pass"
+  }
 }

--- a/SKLADISTE - Copy - Copy/Skladiste.Model/EmailPdfRequest.cs
+++ b/SKLADISTE - Copy - Copy/Skladiste.Model/EmailPdfRequest.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skladiste.Model
+{
+    public class EmailPdfRequest
+    {
+        public string PdfBase64 { get; set; }
+    }
+}

--- a/SKLADISTE - Copy - Copy/Skladiste.Model/EmailSettings.cs
+++ b/SKLADISTE - Copy - Copy/Skladiste.Model/EmailSettings.cs
@@ -1,0 +1,11 @@
+namespace Skladiste.Model
+{
+    public class EmailSettings
+    {
+        public string FromAddress { get; set; }
+        public string SmtpHost { get; set; }
+        public int SmtpPort { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmailSettings` configuration class
- configure `Startup` to load email settings
- inject settings into `Service` and use when sending PDF emails
- update `appsettings.json` with placeholder email config

## Testing
- `npm run lint` *(fails: many React unused-vars errors)*
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687914aee98c8325ba44b9f6747a33f3