### PR TITLE
Set UseDefaultCredentials flag for email SMTP

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Service/Service.cs
@@ -191,6 +191,7 @@ namespace SKLADISTE.Service
 
                 using var client = new System.Net.Mail.SmtpClient(_emailSettings.SmtpHost, _emailSettings.SmtpPort)
                 {
+                    UseDefaultCredentials = false,
                     Credentials = new System.Net.NetworkCredential(_emailSettings.Username, _emailSettings.Password),
                     EnableSsl = true
                 };


### PR DESCRIPTION
## Summary
- update `SendNarudzbenicaEmailAsync` so SMTP clients don't use default credentials

## Testing
- `dotnet build 'SKLADISTE - Copy - Copy/SKLADISTE.sln' -c Release` *(fails: No usable version of libssl was found)*

------
https://chatgpt.com/codex/tasks/task_e_68792782ce9c8325a9b09d679abb096f