### PR TITLE
Enable safe article deletion

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.Repository/Repository.cs
@@ -322,6 +322,13 @@ namespace SKLADISTE.Repository
             {
                 return false;
             }
+
+            bool hasDocuments = await _appDbContext.ArtikliDokumenata.AnyAsync(ad => ad.ArtiklId == artiklId);
+            if (hasDocuments)
+            {
+                return false;
+            }
+
             _appDbContext.Artikli.Remove(artikl);
             await _appDbContext.SaveChangesAsync();
             return true;

--- a/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.WebAPI/Controllers/HomeController.cs
@@ -389,6 +389,7 @@ namespace SKLADISTE.WebAPI.Controllers
                 return StatusCode(500, "Internal server error");
             }
         }
+        [Authorize(Roles = "Administrator")]
         [HttpDelete("delete_artikl/{id}")]
         public async Task<IActionResult> DeleteArtikl(int id)
         {
@@ -399,7 +400,7 @@ namespace SKLADISTE.WebAPI.Controllers
                 return NoContent(); // 204 No Content on successful delete
             }
 
-            return NotFound(); // 404 Not Found if Artikl doesn't exist
+            return BadRequest("Ne može se obrisati artikl. Možda postoje povezani dokumenti ili artikl ne postoji.");
         }
 
         [HttpGet("joined_narudzbenice")]

--- a/VUVSkladiste/src/assets/ArtiklInfo.jsx
+++ b/VUVSkladiste/src/assets/ArtiklInfo.jsx
@@ -12,10 +12,36 @@ function ArtiklInfo() {
     const [jmjOptions, setJmjOptions] = useState([]);
     const [kategorijeOptions, setKategorijeOptions] = useState([]);
     const [showEditModal, setShowEditModal] = useState(false);
+    const [userDetails, setUserDetails] = useState({ username: '', roles: [] });
     const navigate = useNavigate();
 
     const handleShowEditModal = () => setShowEditModal(true);
     const handleCloseEditModal = () => setShowEditModal(false);
+
+    const handleDeleteArtikl = async () => {
+        try {
+            await axios.delete(`https://localhost:5001/api/home/delete_artikl/${artiklDetails.artiklId}`, {
+                headers: {
+                    'Authorization': `Bearer ${sessionStorage.getItem('token')}`
+                }
+            });
+            alert(`Artikl s ID-om ${artiklDetails.artiklId} je obrisan.`);
+            navigate('/stanja');
+        } catch (error) {
+            console.error("Greška prilikom brisanja artikla:", error);
+            alert("Greška prilikom brisanja artikla");
+        }
+    };
+
+    useEffect(() => {
+        const token = sessionStorage.getItem('token');
+        const username = sessionStorage.getItem('Username');
+        const roles = JSON.parse(sessionStorage.getItem('Role') || '[]');
+
+        if (token) {
+            setUserDetails({ username, roles });
+        }
+    }, []);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -121,6 +147,9 @@ function ArtiklInfo() {
                 </Table>
 
                 <div className="d-flex justify-content-end mt-3">
+                    {userDetails.roles.includes('Administrator') && artiklData.length === 0 && (
+                        <Button variant="danger" className="me-2" onClick={handleDeleteArtikl}>Obriši</Button>
+                    )}
                     <Button variant="primary" className="me-2" onClick={handleShowEditModal}>Uredi</Button>
                     <Button variant="secondary" onClick={() => navigate('/stanja')}>Natrag</Button>
                 </div>


### PR DESCRIPTION
## Summary
- add admin-aware delete button in `ArtiklInfo` page
- prevent deleting articles tied to documents
- restrict delete endpoint to administrators only

## Testing
- `dotnet build`
- `npm run lint` *(fails: React unused-vars and prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879481295b88325803018334acb8243