### PR TITLE
Allow null supplier id in Izdatnica

### DIFF
--- a/SKLADISTE - Copy - Copy/SKLADISTE.DAL/DataModel/Dokument.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.DAL/DataModel/Dokument.cs
@@ -13,7 +13,7 @@ namespace SKLADISTE.DAL.DataModel
         public string ZaposlenikId { get; set; }
         public string Napomena { get; set; }
         public string MjestoTroska { get; set; }
-        public int DobavljacId { get; set; }
+        public int? DobavljacId { get; set; }
         public string Dostavio {  get; set; }
         public ICollection<ArtikliDokumenata> ArtikliDokumenata { get; set; }
 

--- a/SKLADISTE - Copy - Copy/SKLADISTE.DAL/DataModel/SkladisteKresonjaDbContext.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.DAL/DataModel/SkladisteKresonjaDbContext.cs
@@ -64,7 +64,8 @@ namespace SKLADISTE.DAL.DataModel
 
 
             modelBuilder.Entity<Dokument>()
-                .Property(d => d.DobavljacId);
+                .Property(d => d.DobavljacId)
+                .IsRequired(false);
                 
 
             modelBuilder.Entity<Dokument>()

--- a/SKLADISTE - Copy - Copy/SKLADISTE.DAL/Migrations/20250725120000_DobavljacIdNullable.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.DAL/Migrations/20250725120000_DobavljacIdNullable.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SKLADISTE.DAL.Migrations
+{
+    public partial class DobavljacIdNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "DobavljacId",
+                table: "Dokumenti",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "DobavljacId",
+                table: "Dokumenti",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true);
+        }
+    }
+}

--- a/SKLADISTE - Copy - Copy/SKLADISTE.DAL/Migrations/SkladisteKresonjaDbContextModelSnapshot.cs
+++ b/SKLADISTE - Copy - Copy/SKLADISTE.DAL/Migrations/SkladisteKresonjaDbContextModelSnapshot.cs
@@ -321,7 +321,7 @@ namespace SKLADISTE.DAL.Migrations
                     b.Property<DateTime>("DatumDokumenta")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("DobavljacId")
+                    b.Property<int?>("DobavljacId")
                         .HasColumnType("int");
 
                     b.Property<string>("Dostavio")
@@ -514,8 +514,7 @@ namespace SKLADISTE.DAL.Migrations
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
@@ -589,8 +588,7 @@ namespace SKLADISTE.DAL.Migrations
                     b.HasOne("SKLADISTE.DAL.DataModel.Dobavljac", null)
                         .WithMany("Dokumenti")
                         .HasForeignKey("DobavljacId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("SKLADISTE.DAL.DataModel.DokumentTip", "TipDokumenta")
                         .WithMany("Dokumenti")

--- a/SKLADISTE - Copy - Copy/Skladiste.Model/DokumentDto.cs
+++ b/SKLADISTE - Copy - Copy/Skladiste.Model/DokumentDto.cs
@@ -11,6 +11,6 @@ namespace Skladiste.Model
         public DateTime DatumDokumenta { get; set; }
         public string Napomena { get; set; }
         public string TipDokumenta { get; set; }
-        public int DobavljacId { get; set; }
+        public int? DobavljacId { get; set; }
     }
 }

--- a/VUVSkladiste/src/assets/IzdatnicaArtikliPage.jsx
+++ b/VUVSkladiste/src/assets/IzdatnicaArtikliPage.jsx
@@ -45,7 +45,7 @@ function IzdatnicaArtikliPage() {
             TipDokumentaId: 2,
             ZaposlenikId: UserId,
             Napomena: napomena,
-            DobavljacId: 1,
+            DobavljacId: null,
             OznakaDokumenta: oznaka,
             MjestoTroska: mjestoTroska
         };

--- a/VUVSkladiste/src/assets/modals.jsx
+++ b/VUVSkladiste/src/assets/modals.jsx
@@ -750,6 +750,7 @@ export const IzdatnicaArtikliModal = ({ show, handleClose, dodaniArtikli, datumI
             DokumentId: 0,
             DatumDokumenta: formattedDate, // Use the formatted date here
             TipDokumentaId: 2,
+            DobavljacId: null,
             ZaposlenikId: UserId
         };
 


### PR DESCRIPTION
## Summary
- make `DobavljacId` nullable on `Dokument`
- update EF model configuration and snapshot
- add migration to alter the column
- send `DobavljacId: null` when creating an izdatnica

## Testing
- `npm run lint` *(fails: React no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879505e880c83258141bedde40afad8