### PR TITLE
Add document date filters and article selectors

### DIFF
--- a/VUVSkladiste/src/assets/Dokumenti.jsx
+++ b/VUVSkladiste/src/assets/Dokumenti.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import Table from 'react-bootstrap/Table';
-import { Button, Card, Form } from 'react-bootstrap';
+import { Button, Card, Form, Row, Col } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 
 function Dokumenti() {
@@ -10,6 +10,8 @@ function Dokumenti() {
     const [filteredArtikli, setFilteredArtikli] = useState([]);
     const [filterType, setFilterType] = useState("all");
     const [searchTerm, setSearchTerm] = useState("");
+    const [startDate, setStartDate] = useState("");
+    const [endDate, setEndDate] = useState("");
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -50,8 +52,16 @@ function Dokumenti() {
             );
         }
 
+        if (startDate) {
+            filtered = filtered.filter(art => new Date(art.datumDokumenta) >= new Date(startDate));
+        }
+
+        if (endDate) {
+            filtered = filtered.filter(art => new Date(art.datumDokumenta) <= new Date(endDate));
+        }
+
         setFilteredArtikli(filtered);
-    }, [filterType, searchTerm, artikli]);
+    }, [filterType, searchTerm, artikli, startDate, endDate]);
 
     const handleInfoClick = (dokumentId) => {
         navigate(`/dokument-info/${dokumentId}`);
@@ -94,6 +104,15 @@ function Dokumenti() {
                             style={{ width: '80%' }}
                         />
                     </Form.Group>
+
+                    <Row className="mt-2" style={{ width: '80%', margin: '0 auto' }}>
+                        <Col>
+                            <Form.Control type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+                        </Col>
+                        <Col>
+                            <Form.Control type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+                        </Col>
+                    </Row>
 
                     <Table className="centered-table mt-3" striped bordered hover variant="light">
                         <thead>

--- a/VUVSkladiste/src/assets/Narudzbenice.jsx
+++ b/VUVSkladiste/src/assets/Narudzbenice.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import Table from 'react-bootstrap/Table';
-import { Button, Card, Form, ButtonGroup } from 'react-bootstrap';
+import { Button, Card, Form, ButtonGroup, Row, Col } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 
 function Narudzbenice() {
@@ -10,6 +10,8 @@ function Narudzbenice() {
     const [narudzbenice, setNarudzbenice] = useState([]);
     const [filteredNarudzbenice, setFilteredNarudzbenice] = useState([]);
     const [searchTerm, setSearchTerm] = useState("");
+    const [startDate, setStartDate] = useState("");
+    const [endDate, setEndDate] = useState("");
     const [usernames, setUsernames] = useState({});
     const [statusi, setStatusi] = useState({});
     const [rokovi, setRokovi] = useState({});
@@ -108,6 +110,14 @@ function Narudzbenice() {
             );
         }
 
+        if (startDate) {
+            filtered = filtered.filter(art => new Date(art.datumDokumenta) >= new Date(startDate));
+        }
+
+        if (endDate) {
+            filtered = filtered.filter(art => new Date(art.datumDokumenta) <= new Date(endDate));
+        }
+
         if (filterStatus !== "sve") {
             filtered = filtered.filter(n => {
                 const status = statusi[n.dokumentId]?.toLowerCase();
@@ -118,7 +128,7 @@ function Narudzbenice() {
         }
 
         setFilteredNarudzbenice(filtered);
-    }, [searchTerm, narudzbenice, filterStatus, statusi]);
+    }, [searchTerm, narudzbenice, filterStatus, statusi, startDate, endDate]);
 
     const handleShowInfoPage = (dokumentId) => {
         navigate(`/narudzbenica/${dokumentId}`);
@@ -161,6 +171,15 @@ function Narudzbenice() {
                             style={{ width: '80%' }}
                         />
                     </Form.Group>
+
+                    <Row className="mt-2" style={{ width: '80%', margin: '0 auto' }}>
+                        <Col>
+                            <Form.Control type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+                        </Col>
+                        <Col>
+                            <Form.Control type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+                        </Col>
+                    </Row>
 
                     <Table className="centered-table mt-3" striped bordered hover variant="light">
                         <thead>

--- a/VUVSkladiste/src/assets/Stanja.jsx
+++ b/VUVSkladiste/src/assets/Stanja.jsx
@@ -20,6 +20,8 @@ function Stanja() {
     const [selectedArtiklKategorija, setselectedArtiklKategorija] = useState('');
     const [selectedArtiklId, setSelectedArtiklId] = useState('');
     const [searchTerm, setSearchTerm] = useState('');
+    const [filterJmj, setFilterJmj] = useState('');
+    const [filterKategorija, setFilterKategorija] = useState('');
     const [userDetails, setUserDetails] = useState({ username: '', roles: [] });
 
     const navigate = useNavigate();
@@ -176,13 +178,16 @@ function Stanja() {
         }
     };
 
-    const filteredArtikli = artikli.filter((art) =>
-        art.artiklId.toString().includes(searchTerm) ||
-        art.artiklNaziv.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        art.artiklJmj.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        art.kategorijaNaziv.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (art.kolicinaUlaz !== undefined && art.kolicinaUlaz.toString().includes(searchTerm))
-    );
+    const filteredArtikli = artikli
+        .filter(art => (filterJmj ? art.artiklJmj === filterJmj : true))
+        .filter(art => (filterKategorija ? art.kategorijaNaziv === filterKategorija : true))
+        .filter(art =>
+            art.artiklId.toString().includes(searchTerm) ||
+            art.artiklNaziv.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            art.artiklJmj.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            art.kategorijaNaziv.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (art.kolicinaUlaz !== undefined && art.kolicinaUlaz.toString().includes(searchTerm))
+        );
 
     const stanjaFix = (stanje) => stanje || 0;
 
@@ -228,6 +233,21 @@ function Stanja() {
                         />
 
                     </Form.Group>
+
+                    <div className="d-flex justify-content-center gap-2 mt-2">
+                        <Form.Select value={filterJmj} onChange={e => setFilterJmj(e.target.value)} style={{ width: '40%' }}>
+                            <option value="">Sve JMJ</option>
+                            {jmjOptions.map(j => (
+                                <option key={j} value={j}>{j}</option>
+                            ))}
+                        </Form.Select>
+                        <Form.Select value={filterKategorija} onChange={e => setFilterKategorija(e.target.value)} style={{ width: '40%' }}>
+                            <option value="">Sve kategorije</option>
+                            {kategorijeOptions.map(k => (
+                                <option key={k.kategorijaNaziv} value={k.kategorijaNaziv}>{k.kategorijaNaziv}</option>
+                            ))}
+                        </Form.Select>
+                    </div>
 
                     <Table striped bordered hover variant="light">
                         <thead>


### PR DESCRIPTION
## Summary
- allow filtering documents and narudzbenice by start and end date
- allow filtering articles by measurement unit or category

## Testing
- `npm run lint` *(fails: React unused-var errors)*

------
https://chatgpt.com/codex/tasks/task_e_68798b41c8c48325a59de1d3ddbe2e98